### PR TITLE
allow passing secrets to PRs

### DIFF
--- a/.github/workflows/python-app.yml
+++ b/.github/workflows/python-app.yml
@@ -6,7 +6,7 @@ name: Python application
 on:
   push:
     branches: [ main ]
-  pull_request:
+  pull_request_target:
     branches: [ main ]
 
 jobs:


### PR DESCRIPTION
replaced pull_request trigger with pull_request_target
the pull_request trigger simplied ignores all secrets except GITHUB_TOKEN to prevent malicious actors to gather secrets
pull_request_target *should* allow the usage of project secrets in PR

#17


- [ ] This issue was assigned to me
- [x] One Change in one Pull Request
- [x] My file is in proper folder
- [x] I am following clean code and Documentation.
- [ ] I have added README.md with my script
